### PR TITLE
Fix app.use() for Koa 2.x

### DIFF
--- a/koa-logger.js
+++ b/koa-logger.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const co = require('co')
 const levels = require('log4js').levels
 const DEFAULT_FORMAT = ':remote-addr - -' +
   ' ":method :url HTTP/:http-version"' +

--- a/koa-logger.js
+++ b/koa-logger.js
@@ -48,12 +48,13 @@ function getKoaLogger (logger4js, options) {
   var fmt = options.format || DEFAULT_FORMAT
   var nolog = options.nolog ? createNoLogCondition(options.nolog) : null
 
-  return co.wrap(function *(ctx, next) {
+  return function *(next) {
+    var ctx = this;
     // mount safety
-    if (ctx.request._logging) return yield next()
+    if (ctx.request._logging) return yield next
 
 		// nologs
-    if (nolog && nolog.test(ctx.originalUrl)) return yield next()
+    if (nolog && nolog.test(ctx.originalUrl)) return yield next
     if (thislogger.isLevelEnabled(level) || options.level === 'auto') {
       var start = new Date()
       var writeHead = ctx.response.writeHead
@@ -78,7 +79,7 @@ function getKoaLogger (logger4js, options) {
         }
       }
 
-      yield next()
+      yield next
 			// hook on end request to emit the log entry of the HTTP request.
       ctx.response.responseTime = new Date() - start
 			// status code response level handling
@@ -100,9 +101,9 @@ function getKoaLogger (logger4js, options) {
       }
     } else {
       // ensure next gets always called
-      yield next()
+      yield next
     }
-  })
+  }
 }
 
 /**


### PR DESCRIPTION
- Unwrapped return value of getKoaLogger (Returns generator function instead of co.wrap() result)
- Removed function call from yield next() to become simply yield next
- Replaced passed in ctx variable with "this" provided by Koa framework

Fixes issue #2
Tested in my Koa app locally, it works for the Koa Middleware Use Case. ^^