### PR TITLE
 update log4js to 2.3.x

### DIFF
--- a/koa-logger.js
+++ b/koa-logger.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const levels = require('log4js').levels
-var DEFAULT_FORMAT = ':remote-addr - -' +
+const DEFAULT_FORMAT = ':remote-addr - -' +
   ' ":method :url HTTP/:http-version"' +
   ' :status :content-length ":referrer"' +
   ' ":user-agent"'
@@ -42,21 +42,21 @@ function getKoaLogger (logger4js, options) {
     options = {}
   }
 
-  var thislogger = logger4js
-  var level = levels.toLevel(options.level, levels.INFO)
-  var fmt = options.format || DEFAULT_FORMAT
-  var nolog = options.nolog ? createNoLogCondition(options.nolog) : null
+  let thislogger = logger4js
+  let level = levels.getLevel(options.level, levels.INFO)
+  let fmt = options.format || DEFAULT_FORMAT
+  let nolog = options.nolog ? createNoLogCondition(options.nolog) : null
 
   return function *(next) {
-    var ctx = this
+    let ctx = this
     // mount safety
     if (ctx.request._logging) return yield next
 
     // nologs
     if (nolog && nolog.test(ctx.originalUrl)) return yield next
     if (thislogger.isLevelEnabled(level) || options.level === 'auto') {
-      var start = new Date()
-      var writeHead = ctx.response.writeHead
+      let start = new Date()
+      let writeHead = ctx.response.writeHead
 
       // flag as logging
       ctx.request._logging = true
@@ -74,7 +74,7 @@ function getKoaLogger (logger4js, options) {
           if (code >= 300) level = levels.WARN
           if (code >= 400) level = levels.ERROR
         } else {
-          level = levels.toLevel(options.level, levels.INFO)
+          level = levels.getLevel(options.level, levels.INFO)
         }
       }
 
@@ -88,9 +88,9 @@ function getKoaLogger (logger4js, options) {
         if (ctx.res.statusCode >= 400) level = levels.ERROR
       }
       if (thislogger.isLevelEnabled(level)) {
-        var combinedTokens = assembleTokens(ctx, options.tokens || [])
+        let combinedTokens = assembleTokens(ctx, options.tokens || [])
         if (typeof fmt === 'function') {
-          var line = fmt(ctx, function (str) {
+          let line = fmt(ctx, function (str) {
             return format(str, combinedTokens)
           })
           if (line) thislogger.log(level, line)
@@ -119,7 +119,7 @@ function getKoaLogger (logger4js, options) {
  * @return {Array}
  */
 function assembleTokens (ctx, customTokens) {
-  var arrayUniqueTokens = function (array) {
+  let arrayUniqueTokens = function (array) {
     let a = array.concat()
     for (let i = 0; i < a.length; ++i) {
       for (let j = i + 1; j < a.length; ++j) {
@@ -130,7 +130,7 @@ function assembleTokens (ctx, customTokens) {
     }
     return a
   }
-  var defaultTokens = []
+  let defaultTokens = []
   defaultTokens.push({ token: ':url', replacement: ctx.originalUrl })
   defaultTokens.push({ token: ':protocol', replacement: ctx.protocol })
   defaultTokens.push({ token: ':hostname', replacement: ctx.hostname })
@@ -225,7 +225,7 @@ function format (str, tokens) {
  *         SAME AS "\\.jpg|\\.png|\\.gif"
  */
 function createNoLogCondition (nolog) {
-  var regexp = null
+  let regexp = null
   if (nolog) {
     if (nolog instanceof RegExp) {
       regexp = nolog
@@ -236,7 +236,7 @@ function createNoLogCondition (nolog) {
     }
 
     if (Array.isArray(nolog)) {
-      var regexpsAsStrings = nolog.map((o) => (o.source ? o.source : o))
+      let regexpsAsStrings = nolog.map((o) => (o.source ? o.source : o))
       regexp = new RegExp(regexpsAsStrings.join('|'))
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/dominhhai/koa-log4js#readme",
   "dependencies": {
-    "log4js": "^1.0.1"
+    "log4js": "^2.3.12"
   },
   "devDependencies": {
     "standard": "^8.5.0"


### PR DESCRIPTION
fix  #7 
[https://github.com/dominhhai/koa-log4js/issues/7](url)

log4js to 2.3.x
testing OK！

testing code:

```js
const log4 = require('./');
const Koa = require('koa');
const app = Koa();
const appenders = {
  out: {
    type: 'console',
    layout: {
      type: 'pattern',
      pattern: '%[[%d{MM-dd hh:mm:ss SSS} %p ] %c -%] %m%n',
    },
  },
  koajs_test: {
    type: 'dateFile',
    filename: './logs/koajs_test.log',
    pattern: '.yyyyMMddhhmm',
    keepFileExt: true,
    daysToKeep: 120,
    layout: {
      type: 'pattern',
      pattern: '[%d{MM-dd hh:mm:ss SSS} %p ] %c - %m%n',
    },
  },
};


log4.configure({
  appenders: appenders,
  categories: {
    default: { appenders: [ 'out' ], level: 'info' },
    koajs_test: { appenders: [ 'koajs_test', 'out' ], level: 'info' },
  },
});

const logger = log4.getLogger('koajs_test');

app.use(
  log4.koaLogger(
    logger,
    {
      level: 'info',
      format: ':remote-addr - -' +
      ' ":method :url HTTP/:http-version"' +
      ' :status :content-length ":referrer"' +
      ' ":user-agent" ":response-time" | :logStr',
      tokens: [
        {
          token: ':logStr',
          content: function (ctx) {
            return 'logStr';
          },
        },
      ],
    })
);
app.use(function * (next) {
  if (this.request.path === '/') {
    logger.info('testint koa-log4');
  }
  this.body = 'Hello World';
});

app.listen(8000);
```

logout:

```
[11-17 19:06:27 404 INFO ] koajs_test - testint koa-log4

[11-17 19:06:27 415 INFO ] koajs_test - ::1 - - "GET / HTTP/1.1" 200 11 "" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36" "10" | logStr

[11-17 19:06:27 548 INFO ] koajs_test - ::1 - - "GET /favicon.ico HTTP/1.1" 200 11 "http://localhost:8000/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 Safari/537.36" "1" | logStr

```