### PR TITLE
update 2.x log4js to 2.3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ build/Release
 
 # Dependency directory
 node_modules
+.idea
 
 # Optional npm cache directory
 .npm

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/dominhhai/koa-log4js#readme",
   "dependencies": {
-    "log4js": "^0.6.35"
+    "log4js": "^2.3.12"
   },
   "devDependencies": {
     "standard": "^8.5.0"


### PR DESCRIPTION
fix https://github.com/dominhhai/koa-log4js/issues/7

update 2.x log4js to 2.3.x

testing code:

```js
const log4 = require('./')
const Koa = require('koa')
const app = new Koa()
const appenders = {
  out: {
    type: 'console',
    layout: {
      type: 'pattern',
      pattern: '%[[%d{MM-dd hh:mm:ss SSS} %p ] %c -%] %m%n'
    }
  },
  koajs_test: {
    type: 'dateFile',
    filename: './logs/koajs_test.log',
    pattern: '.yyyyMMddhhmm',
    keepFileExt: true,
    daysToKeep: 120,
    layout: {
      type: 'pattern',
      pattern: '[%d{MM-dd hh:mm:ss SSS} %p ] %c - %m%n'
    }
  }
}

log4.configure({
  appenders: appenders,
  categories: {
    default: { appenders: [ 'out' ], level: 'info' },
    koajs_test: { appenders: [ 'koajs_test', 'out' ], level: 'info' }
  }
})

const logger = log4.getLogger('koajs_test')

app.use(
  log4.koaLogger(
    logger,
    {
      level: 'info',
      format: ':remote-addr - -' +
      ' ":method :url HTTP/:http-version"' +
      ' :status :content-length ":referrer"' +
      ' ":user-agent" ":response-time" | :logStr',
      tokens: [
        {
          token: ':logStr',
          content: function (ctx) {
            return 'logStr'
          }
        }
      ]
    })
)

app.use(ctx => {
  if (ctx.request.path === '/') {
    logger.info('testint koa-log4 2.x')
  }
  ctx.body = 'Hello World'
})

app.listen(8000)
```